### PR TITLE
Fix score sending bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -693,7 +693,7 @@ class SalienScript {
 
     await delay(this.waitTime * 1000);
 
-    const report = await this.ApiReportScore(getScoreForZone(zone));
+    const report = await this.ApiReportScore(getScoreForZone(zoneInfo));
 
     if (report.new_score) {
       const earnedXp = report.new_score - report.old_score;


### PR DESCRIPTION
This fixes the bug that always sends a score of 600, irregardless of the zone's difficulty.
The method getScoreForZone(zone) was passed the wrong parameter, thus it returned always the default of 600 instead of the correctly calculated value for this zone's difficulty.
Passing zoneInfo instead of zone fixes this.