### PR TITLE
fix for time remaining using 600xp as default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -703,9 +703,9 @@ class SalienScript {
       const remainingXp = report.next_level_score - report.new_score;
 
       const timeRemaining =
-        ((report.next_level_score - report.new_score) / getScoreForZone(zone)) * (this.waitTime / 60);
+        ((report.next_level_score - report.new_score) / getScoreForZone(zoneInfo)) * (this.waitTime / 60);
       const hoursRemaining = Math.floor(timeRemaining / 60);
-      const minutesRemaining = timeRemaining % 60;
+      const minutesRemaining = Math.round(timeRemaining % 60);
       const levelEta = `${hoursRemaining}h ${minutesRemaining}m`;
 
       let nextLevelMsg = `>> Next Level: ${chalk.yellow(report.next_level_score.toLocaleString())} XP`;


### PR DESCRIPTION
Passing the zoneinfo to the getScoreForZone instead of zone. zone itself doesn't directly have the difficulty attribute, so in the getScoreForZone switch it allways got caught in the default 5xp. Which then caused the time estimation to allways use 600xp which led to a wrong estimation.

Also added Math.round to the minutes remaining 