### PR TITLE
feat: add support for planet selection via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ If you'd like to team up with an established larger group please consider using 
 * [100Pals](https://steamcommunity.com/groups/100pals) id: `103582791454524084`
 * [SteamDB](https://steamcommunity.com/groups/steamdb) id: `103582791434298690`
 
+### 🌌 Select a planet (Optional)
+
+If you would like to override planet selection in favor of a particular one, provide the `--planet` CLI option with the planet ID.
+
+```sh-session
+salien-script-js --token xxxxxxxx --planet 15
+```
+
+---
+
 ### 👥 Multiple tokens/scripts
 
 Simply open another PowerShell window and run `salien-script-js --token yyyyyyyy --name "name of this script"` where `yyyyyyyy` is your other accounts token and `name of this script` if what you'd like to see in the log outputs.

--- a/cli.js
+++ b/cli.js
@@ -16,7 +16,7 @@ const cliOptions = {
     },
     planet: {
       type: 'string',
-      alias: 'p'
+      alias: 'p',
     },
     name: {
       type: 'string',
@@ -40,7 +40,12 @@ const cli = meow(
 );
 
 if (cli.flags.token) {
-  const salien = new SalienScript({ token: cli.flags.token, clan: cli.flags.group, planet: cli.flags.planet, name: cli.flags.name });
+  const salien = new SalienScript({
+    token: cli.flags.token,
+    clan: cli.flags.group,
+    planet: cli.flags.planet,
+    name: cli.flags.name,
+  });
 
   salien.init();
 }

--- a/cli.js
+++ b/cli.js
@@ -14,6 +14,10 @@ const cliOptions = {
       type: 'string',
       alias: 'g',
     },
+    planet: {
+      type: 'string',
+      alias: 'p'
+    },
     name: {
       type: 'string',
       alias: 'n',
@@ -29,13 +33,14 @@ const cli = meow(
     Options
       --token, -t     Your game token.
       --group, -g     The ID of a steam group you'd like to represent. (optional)
+      --planet, -p    Select planet to fight on. (optional)
       --name, -n      Name this instance of the script. (optional)
 `,
   cliOptions,
 );
 
 if (cli.flags.token) {
-  const salien = new SalienScript({ token: cli.flags.token, clan: cli.flags.group, name: cli.flags.name });
+  const salien = new SalienScript({ token: cli.flags.token, clan: cli.flags.group, planet: cli.flags.planet, name: cli.flags.name });
 
   salien.init();
 }

--- a/cli.js
+++ b/cli.js
@@ -43,7 +43,7 @@ if (cli.flags.token) {
   const salien = new SalienScript({
     token: cli.flags.token,
     clan: cli.flags.group,
-    planet: cli.flags.planet,
+    selectedPlanetId: cli.flags.planet,
     name: cli.flags.name,
   });
 

--- a/src/index.js
+++ b/src/index.js
@@ -131,9 +131,10 @@ class SalienScriptRestart {
 }
 
 class SalienScript {
-  constructor({ token, clan, name = null }) {
+  constructor({ token, clan, planet = null, name = null }) {
     this.token = token;
     this.clan = clan;
+    this.planet = planet;
     this.name = name;
 
     this.maxRetries = 3;
@@ -586,22 +587,36 @@ class SalienScript {
         return Number(planetA.id) - Number(planetB.id);
       });
 
-      for (let i = 0; i < priority.length; i += 1) {
-        sortedPlanetIds.forEach(planetId => {
-          const planet = this.knownPlanets.get(planetId);
+      const selectedPlanet = this.knownPlanets.get(this.planet);
 
-          if (this.skippedPlanets.includes(planetId) || !planet[priority[i]]) {
-            return;
-          }
+      if (!selectedPlanet || this.skippedPlanets.includes(this.planet)) {
+        logger(
+          this.name,
+          `>> Selected planet ${chalk.yellow(this.planet)} not available. Slecting next available planet...`,
+        );
+        for (let i = 0; i < priority.length; i += 1) {
+          sortedPlanetIds.forEach(planetId => {
+            const planet = this.knownPlanets.get(planetId);
 
-          if (!planet.state.captured && !this.currentPlanetId) {
-            const planetName = formatPlanetName(planet.state.name);
+            if (this.skippedPlanets.includes(planetId) || !planet[priority[i]]) {
+              return;
+            }
 
-            logger(this.name, `>> Selected planet ${chalk.green(planetId)} (${chalk.green(planetName)})`);
+            if (!planet.state.captured && !this.currentPlanetId) {
+              const planetName = formatPlanetName(planet.state.name);
 
-            this.currentPlanetId = planetId;
-          }
-        });
+              logger(this.name, `>> Selected planet ${chalk.green(planetId)} (${chalk.green(planetName)})`);
+
+              this.currentPlanetId = planetId;
+            }
+          });
+        }
+      } else {
+        if (!selectedPlanet.state.captured && !this.currentPlanetId) {
+          const planetName = formatPlanetName(selectedPlanet.state.name);
+          logger(this.name, `>> Selected planet ${chalk.green(this.planet)} (${chalk.green(planetName)})`);
+          this.currentPlanetId = this.planet;
+        }
       }
 
       if (!this.currentPlanetId) {

--- a/src/index.js
+++ b/src/index.js
@@ -611,12 +611,10 @@ class SalienScript {
             }
           });
         }
-      } else {
-        if (!selectedPlanet.state.captured && !this.currentPlanetId) {
-          const planetName = formatPlanetName(selectedPlanet.state.name);
-          logger(this.name, `>> Selected planet ${chalk.green(this.planet)} (${chalk.green(planetName)})`);
-          this.currentPlanetId = this.planet;
-        }
+      } else if (!selectedPlanet.state.captured && !this.currentPlanetId) {
+        const planetName = formatPlanetName(selectedPlanet.state.name);
+        logger(this.name, `>> Selected planet ${chalk.green(this.planet)} (${chalk.green(planetName)})`);
+        this.currentPlanetId = this.planet;
       }
 
       if (!this.currentPlanetId) {

--- a/src/index.js
+++ b/src/index.js
@@ -131,10 +131,10 @@ class SalienScriptRestart {
 }
 
 class SalienScript {
-  constructor({ token, clan, planet = null, name = null }) {
+  constructor({ token, clan, selectedPlanetId, name = null }) {
     this.token = token;
     this.clan = clan;
-    this.planet = planet;
+    this.selectedPlanetId = selectedPlanetId;
     this.name = name;
 
     this.maxRetries = 3;
@@ -587,13 +587,20 @@ class SalienScript {
         return Number(planetA.id) - Number(planetB.id);
       });
 
-      const selectedPlanet = this.knownPlanets.get(this.planet);
+      // Attempt to get selected planet from provided planet id
+      const selectedPlanet = this.knownPlanets.get(this.selectedPlanetId);
 
-      if (!selectedPlanet || this.skippedPlanets.includes(this.planet)) {
-        logger(
-          this.name,
-          `>> Selected planet ${chalk.yellow(this.planet)} not available. Slecting next available planet...`,
-        );
+      // If the selected planet is not valid, handle it
+      if (!selectedPlanet || this.skippedPlanets.includes(this.selectedPlanetId)) {
+        // Only log if a planet was selected
+        if (this.selectedPlanetId) {
+          logger(
+            this.name,
+            `>> Selected planet ${chalk.yellow(
+              this.selectedPlanetId,
+            )} not available. Selecting next available planet...`,
+          );
+        }
         for (let i = 0; i < priority.length; i += 1) {
           sortedPlanetIds.forEach(planetId => {
             const planet = this.knownPlanets.get(planetId);
@@ -613,8 +620,8 @@ class SalienScript {
         }
       } else if (!selectedPlanet.state.captured && !this.currentPlanetId) {
         const planetName = formatPlanetName(selectedPlanet.state.name);
-        logger(this.name, `>> Selected planet ${chalk.green(this.planet)} (${chalk.green(planetName)})`);
-        this.currentPlanetId = this.planet;
+        logger(this.name, `>> Selected planet ${chalk.green(this.selectedPlanetId)} (${chalk.green(planetName)})`);
+        this.currentPlanetId = this.selectedPlanetId;
       }
 
       if (!this.currentPlanetId) {


### PR DESCRIPTION
Adds feature to pass `-p <planet_id>` or `--planet <planet_id>` in CLI.
Script will attempt to use the planet if its available, otherwise the default behavior will be used.