### PR TITLE
Use actual app name as user agent, instead of browser's one

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,7 +6,11 @@
     "SALIEN_CONFIG_V2": {
       "description": "A config JSON for salien script.",
       "value": "[{\"token\": \"PUT_YOUR_TOKEN_HERE\"}]"
-    }
+    },
+    "SALIEN_UA": {
+        "description": "Set to 0 or leave empty to use browser user-agent, otherwise cheat's specific user-agent will be used",
+        "value": "1"
+      }
   },
   "formation": {
     "web": {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -26,7 +26,9 @@ const doFetch = async (method, params, requestOptions = {}, logger, isSilentRequ
       Origin: 'https://steamcommunity.com',
       Referer: 'https://steamcommunity.com/saliengame/play/',
       'User-Agent':
-        'salien-script-js (https://github.com/South-Paw/salien-script-js)',
+        process.env.SALIEN_UA && process.env.SALIEN_UA !== "0"
+          ? 'salien-script-js (https://github.com/South-Paw/salien-script-js)'
+          : 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36',
     },
     ...requestOptions,
   };

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -26,7 +26,7 @@ const doFetch = async (method, params, requestOptions = {}, logger, isSilentRequ
       Origin: 'https://steamcommunity.com',
       Referer: 'https://steamcommunity.com/saliengame/play/',
       'User-Agent':
-        'Mozilla/5.0 (compatible; salien-script-js; +https://github.com/South-Paw/salien-script-js)',
+        'salien-script-js (https://github.com/South-Paw/salien-script-js)',
     },
     ...requestOptions,
   };

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -26,7 +26,7 @@ const doFetch = async (method, params, requestOptions = {}, logger, isSilentRequ
       Origin: 'https://steamcommunity.com',
       Referer: 'https://steamcommunity.com/saliengame/play/',
       'User-Agent':
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36',
+        'Mozilla/5.0 (compatible; salien-script-js; +https://github.com/South-Paw/salien-script-js)',
     },
     ...requestOptions,
   };


### PR DESCRIPTION
It seems that volve doesn't care for it, but it might solve being banned on heroku problem.