### PR TITLE
Ignore zones that don't have a gameid

### DIFF
--- a/src/game/index.js
+++ b/src/game/index.js
@@ -80,10 +80,10 @@ const getAllPlanetStates = async (planets, completionCutoff, logger, isSilentReq
       const bossZones = [];
 
       planet.zones.forEach(zone => {
-        const { capture_progress: captureProgress, captured, type, difficulty } = zone;
+        const { capture_progress: captureProgress, captured, type, difficulty, gameid } = zone;
 
-        // disregard this zone if its close to being captured or already captured
-        if ((captureProgress && captureProgress > completionCutoff) || captured || captureProgress === 0) {
+        // disregard this zone if there is no gameid, it's close to being captured or already captured
+        if (!gameid || (captureProgress && captureProgress > completionCutoff) || captured || captureProgress === 0) {
           return;
         }
 


### PR DESCRIPTION
https://github.com/South-Paw/salien-script-js/pull/50/commits/143a5baef578b963ce4d11fa3dd83dd658343806 was failing for me. Looking at the response `captureProgress` is missing so it will be undefined. Since `gameid` is also missing we should be able to use this to assume the zone is broken.

Edit: Response now comes back with valid data but the zone is still broken, so checking `captureProgress === 0` is still valid.

![Response](https://i.imgur.com/KsohmcW.png)